### PR TITLE
Add climate news section and fix zoom controls

### DIFF
--- a/skys-app/.env.example
+++ b/skys-app/.env.example
@@ -1,1 +1,2 @@
-REACT_APP_WAQI_API_KEY=your_api_key_here
+REACT_APP_WAQI_API_KEY=your_waqi_api_key_here
+REACT_APP_NEWS_API_KEY=your_newsapi_key_here

--- a/skys-app/src/App.js
+++ b/skys-app/src/App.js
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import './App.css';
 import SimpleMap from './SimpleMap';
 import SearchLocation from './SearchLocation';
+import NewsSection from './components/NewsSection';
 
 function App() {
   const mapRef = useRef(null);

--- a/skys-app/src/SimpleMap.css
+++ b/skys-app/src/SimpleMap.css
@@ -100,12 +100,20 @@
 }
 
 /* Move Leaflet zoom controls to bottom right */
-.simple-map .leaflet-control-zoom {
-  position: absolute;
-  bottom: 20px;
-  right: 10px;
-  top: auto;
-  left: auto;
+.leaflet-control-zoom {
+  position: absolute !important;
+  bottom: 20px !important;
+  right: 10px !important;
+  top: auto !important;
+  left: auto !important;
+  z-index: 1001 !important;
+}
+
+.leaflet-top.leaflet-left {
+  top: auto !important;
+  left: auto !important;
+  bottom: 20px !important;
+  right: 10px !important;
 }
 
 .simple-map {

--- a/skys-app/src/SimpleMap.jsx
+++ b/skys-app/src/SimpleMap.jsx
@@ -4,6 +4,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import './SimpleMap.css';
 import AirQualityMarker from './components/AirQualityMarker';
+import NewsSection from './components/NewsSection';
 import { fetchAirQualityData, getAirQualitySummary, isDangerousAirQuality } from './services/airQualityService';
 
 // Fix for default markers in react-leaflet
@@ -217,6 +218,9 @@ const SimpleMap = forwardRef((props, ref) => {
             ) : null}
           </div>
         )}
+
+        {/* News Section Overlay - Below AQI box */}
+        <NewsSection />
       </MapContainer>
       {error && (
         <div className="map-warning">

--- a/skys-app/src/components/NewsSection.css
+++ b/skys-app/src/components/NewsSection.css
@@ -1,0 +1,159 @@
+/* News Section Overlay - Bottom Left */
+
+.news-section {
+  position: absolute;
+  bottom: 20px;
+  left: 10px;
+  z-index: 1000;
+  width: 320px;
+  background: rgba(0, 0, 0, 0.9);
+  backdrop-filter: blur(15px);
+  border-radius: 12px;
+  border: 1px solid rgba(120, 219, 255, 0.3);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  padding: 14px;
+  pointer-events: auto;
+}
+
+.news-header {
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(120, 219, 255, 0.2);
+}
+
+.news-header h2 {
+  font-size: 15px;
+  font-weight: 600;
+  color: white;
+  margin: 0;
+}
+
+.news-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+/* Custom scrollbar for news grid */
+.news-grid::-webkit-scrollbar {
+  width: 5px;
+}
+
+.news-grid::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 3px;
+}
+
+.news-grid::-webkit-scrollbar-thumb {
+  background: rgba(120, 219, 255, 0.4);
+  border-radius: 3px;
+}
+
+.news-grid::-webkit-scrollbar-thumb:hover {
+  background: rgba(120, 219, 255, 0.6);
+}
+
+.news-card {
+  text-decoration: none;
+  display: block;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: all 0.2s ease;
+}
+
+.news-card:hover {
+  border-color: rgba(120, 219, 255, 0.5);
+  background: rgba(120, 219, 255, 0.1);
+  transform: translateX(4px);
+}
+
+.news-card:hover .news-title {
+  color: #78DBFF;
+}
+
+.news-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: white;
+  margin: 0 0 6px 0;
+  line-height: 1.4;
+  transition: color 0.2s ease;
+}
+
+.news-meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 11px;
+}
+
+.news-source {
+  color: rgba(120, 219, 255, 0.8);
+  font-weight: 500;
+}
+
+.news-date {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+/* Loading state */
+.news-loading {
+  text-align: center;
+  padding: 60px 20px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.news-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  border-top: 3px solid #78DBFF;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 16px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.news-loading p {
+  margin: 0;
+  font-size: 14px;
+}
+
+/* Error state */
+.news-error {
+  text-align: center;
+  padding: 40px 20px;
+  color: rgba(255, 100, 100, 0.8);
+  background: rgba(255, 100, 100, 0.1);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 100, 100, 0.2);
+}
+
+.news-error p {
+  margin: 0;
+  font-size: 14px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .news-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .news-header h2 {
+    font-size: 24px;
+  }
+
+  .news-card {
+    padding: 16px;
+  }
+}

--- a/skys-app/src/components/NewsSection.jsx
+++ b/skys-app/src/components/NewsSection.jsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect } from 'react';
+import './NewsSection.css';
+
+const NewsSection = () => {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const NEWS_API_KEY = process.env.REACT_APP_NEWS_API_KEY;
+
+  useEffect(() => {
+    const fetchNews = async () => {
+      try {
+        setLoading(true);
+        // Search for air quality and pollution related news only
+        const response = await fetch(
+          `https://newsapi.org/v2/everything?q="air quality" OR "air pollution" OR "PM2.5" OR smog OR emissions&language=en&sortBy=publishedAt&pageSize=20&apiKey=${NEWS_API_KEY}`
+        );
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch news');
+        }
+
+        const data = await response.json();
+
+        // Filter to only show articles actually about air quality/pollution/climate
+        const filteredArticles = (data.articles || []).filter(article => {
+          const text = `${article.title} ${article.description || ''}`.toLowerCase();
+          return text.includes('air') || text.includes('pollution') || text.includes('quality') ||
+                 text.includes('pm2.5') || text.includes('smog') || text.includes('emission') ||
+                 text.includes('climate') || text.includes('environment');
+        });
+
+        console.log('Filtered articles:', filteredArticles.length);
+        setArticles(filteredArticles);
+      } catch (err) {
+        console.error('Error fetching news:', err);
+        setError('Unable to load news articles');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (NEWS_API_KEY) {
+      fetchNews();
+    } else {
+      setError('News API key not configured');
+      setLoading(false);
+    }
+  }, [NEWS_API_KEY]);
+
+  if (loading) {
+    return (
+      <div className="news-section">
+        <div className="news-header">
+          <h2>📰 Air Quality News & Insights</h2>
+        </div>
+        <div className="news-loading">
+          <div className="news-spinner"></div>
+          <p>Loading latest news...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="news-section">
+        <div className="news-header">
+          <h2>📰 Air Quality News & Insights</h2>
+        </div>
+        <div className="news-error">
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="news-section">
+      <div className="news-header">
+        <h2>🌍 Climate News</h2>
+      </div>
+
+      <div className="news-grid">
+        {articles.slice(0, 5).map((article, index) => (
+          <a
+            key={index}
+            href={article.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="news-card"
+          >
+            <h3 className="news-title">{article.title}</h3>
+            <div className="news-meta">
+              <span className="news-source">{article.source?.name}</span>
+              <span className="news-date">
+                {new Date(article.publishedAt).toLocaleDateString()}
+              </span>
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default NewsSection;


### PR DESCRIPTION
- Add NewsSection component with NewsAPI integration
- Display 20 scrollable climate/air quality articles
- Position news box at bottom-left of map
- Move zoom controls to bottom-right
- Update .env.example with NEWS_API_KEY