### PR TITLE
Improve air quality marker visibility and remove duplicate status box

### DIFF
--- a/skys-app/src/SimpleMap.jsx
+++ b/skys-app/src/SimpleMap.jsx
@@ -234,46 +234,6 @@ const SimpleMap = forwardRef((props, ref) => {
           <MeteomaticsDemo lat={position[0]} lon={position[1]} />
         </div>
       )}
-      
-      {/* Air Quality Status */}
-      {airQualityLoading && (
-        <div className="air-quality-status loading">
-          <div className="status-spinner"></div>
-          <p>Loading air quality data...</p>
-        </div>
-      )}
-      
-      {airQualityError && (
-        <div className="air-quality-status error">
-          <p>{airQualityError}</p>
-        </div>
-      )}
-      
-      {!airQualityLoading && !airQualityError && airQualityData.length > 0 && (
-        <div className="air-quality-status">
-          <div className="status-header">
-            <h4>🌫️ Air Quality Status</h4>
-            <span className="sensor-count">{airQualityData.length} sensor{airQualityData.length !== 1 ? 's' : ''} nearby</span>
-          </div>
-          <div className="status-summary">
-            {getAirQualitySummary(airQualityData).status !== 'No Data' ? (
-              <div className="summary-card">
-                <div className="summary-indicator" style={{ backgroundColor: getAirQualitySummary(airQualityData).color }}>
-                  <span className="summary-value">
-                    {getAirQualitySummary(airQualityData).pm25 ? Math.round(getAirQualitySummary(airQualityData).pm25) : '?'} μg/m³
-                  </span>
-                  <span className="summary-category">{getAirQualitySummary(airQualityData).status}</span>
-                </div>
-                <p className="summary-message">{getAirQualitySummary(airQualityData).message}</p>
-              </div>
-            ) : (
-              <div className="no-data">
-                <p>No air quality data available for this area</p>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 });

--- a/skys-app/src/components/AirQualityMarker.css
+++ b/skys-app/src/components/AirQualityMarker.css
@@ -63,12 +63,14 @@
   font-size: 18px;
   font-weight: bold;
   margin-bottom: 4px;
+  color: #000;
 }
 
 .aqi-category {
   font-size: 12px;
   font-weight: 500;
   opacity: 0.9;
+  color: #000;
 }
 
 .pollutants-grid {

--- a/skys-app/src/components/AirQualityMarker.jsx
+++ b/skys-app/src/components/AirQualityMarker.jsx
@@ -6,22 +6,22 @@ import './AirQualityMarker.css';
 
 // Create custom icon for air quality markers
 const createAirQualityIcon = (pm25, aqiColor) => {
-  const iconSize = 25;
+  const iconSize = 35;
   const iconHtml = `
     <div style="
       width: ${iconSize}px;
       height: ${iconSize}px;
       background: ${aqiColor};
-      border: 3px solid white;
+      border: 4px solid white;
       border-radius: 50%;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.5), 0 0 0 2px rgba(0,0,0,0.2);
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 12px;
+      font-size: 14px;
       font-weight: bold;
-      color: white;
-      text-shadow: 1px 1px 2px rgba(0,0,0,0.7);
+      color: #000;
+      text-shadow: none;
     ">
       ${pm25 ? Math.round(pm25) : '?'}
     </div>
@@ -37,21 +37,25 @@ const createAirQualityIcon = (pm25, aqiColor) => {
 
 const AirQualityMarker = memo(({ data }) => {
   const { coordinates, pm25, pm10, no2, o3, co, aqiColor, aqiCategory, healthRecommendation, location, city, country, lastUpdated } = data;
-  
+
   const customIcon = createAirQualityIcon(pm25, aqiColor);
-  
+
+  // Offset marker slightly to avoid overlapping with location marker
+  const offsetLat = coordinates.latitude + 0.001;
+  const offsetLng = coordinates.longitude + 0.001;
+
   const formatValue = (value, unit = 'μg/m³') => {
     if (value === null || value === undefined) return 'No data';
     return `${Math.round(value)} ${unit}`;
   };
-  
+
   const formatDate = (dateString) => {
     if (!dateString) return 'Unknown';
     return new Date(dateString).toLocaleString();
   };
-  
+
   return (
-    <Marker position={[coordinates.latitude, coordinates.longitude]} icon={customIcon}>
+    <Marker position={[offsetLat, offsetLng]} icon={customIcon}>
       <Popup className="air-quality-popup">
         <div className="air-quality-popup-content">
           <div className="popup-header">


### PR DESCRIPTION
- Make AQ marker larger (35px) and more visible with stronger shadow
- Offset marker to avoid overlapping with location pin
- Change marker text to black for better contrast
- Remove duplicate air quality status box from bottom
- Update popup text colors to black for better readability